### PR TITLE
feat: add /init command to generate GEMINI.md project guide

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -20,6 +20,7 @@ import { editorCommand } from '../ui/commands/editorCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
+import { initCommand } from '../ui/commands/initCommand.js';
 import { mcpCommand } from '../ui/commands/mcpCommand.js';
 import { memoryCommand } from '../ui/commands/memoryCommand.js';
 import { privacyCommand } from '../ui/commands/privacyCommand.js';
@@ -58,6 +59,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       extensionsCommand,
       helpCommand,
       ideCommand(this.config),
+      initCommand,
       mcpCommand,
       memoryCommand,
       privacyCommand,

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SlashCommand, CommandKind } from './types.js';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export const initCommand: SlashCommand = {
+  name: 'init',
+  description: 'create GEMINI.md project guide',
+  kind: CommandKind.BUILT_IN,
+  action: async (context, args) => {
+    const { config } = context.services;
+
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: 'Configuration not available.',
+      };
+    }
+
+    const projectRoot = config.getProjectRoot();
+    const geminiMdPath = path.join(projectRoot, 'GEMINI.md');
+
+    // Check if GEMINI.md already exists
+    let fileExists = false;
+    try {
+      await fs.access(geminiMdPath);
+      fileExists = true;
+    } catch {
+      // File doesn't exist, continue
+    }
+
+    if (fileExists && !args.includes('--force')) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: 'GEMINI.md already exists. Use "/init --force" to overwrite it.',
+      };
+    }
+
+    // Return a query action that will automatically send the prompt
+    return {
+      type: 'query',
+      query: `Please analyze the project structure and create a comprehensive GEMINI.md file that provides guidance for AI assistants working with this project.
+
+You have access to these tools:
+- **list_directory**: List files and folders in a directory
+- **glob**: Find files matching patterns (e.g., "**/*.json", "packages/*/src/**/*.ts")
+- **search_file_content**: Search for text patterns in files (grep)
+- **read_file**: Read the contents of a file
+- **read_many_files**: Read multiple files at once
+- **run_shell_command**: Execute shell commands like find, ls, etc.
+- **write_file**: Create or overwrite a file with content
+
+IMPORTANT: Follow these steps in order:
+
+1. **First, discover the project structure:**
+   - Use 'list_directory' to explore the root directory
+   - Use 'run_shell_command' with commands like 'find . -type f -name "*.json" | head -20' to find configuration files
+   - Use 'search_file_content' to search for key patterns like "build", "test", "lint" in package.json files
+   - Use 'glob' to find all package.json files, README files, and documentation (e.g., "**/*.md", "**/package.json")
+
+2. **Then, analyze what you found:**
+   - Use 'read_file' on README.md and any other documentation files
+   - Use 'read_many_files' to read all package.json files at once
+   - Look for configuration files (tsconfig.json, eslint configs, prettier configs)
+   - Check if CLAUDE.md exists and read it to understand the expected format
+
+3. **Explore the codebase architecture:**
+   - Use 'search_file_content' to find main entry points, exports, and key patterns
+   - Use 'read_file' on the main source files you discovered
+   - Use 'glob' to understand the folder structure (e.g., "packages/*/src/**/*.ts")
+
+4. **Finally, create GEMINI.md with these sections:**
+   - **Project Overview**: Brief description based on what you learned
+   - **Architecture**: Key architectural patterns and structure
+   - **Development Commands**: All npm scripts found in package.json files
+   - **Code Style Guidelines**: Based on eslint/prettier configs and observed patterns
+   - **Testing Requirements**: Based on test scripts and test file patterns
+   - **Important Notes**: Any special considerations you discovered
+
+Use 'write_file' to create GEMINI.md in the project root with all your findings.`,
+    };
+  },
+};

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -31,11 +31,23 @@ export const initCommand: SlashCommand = {
     try {
       await fs.access(geminiMdPath);
       fileExists = true;
-    } catch {
-      // File doesn't exist, continue
+    } catch (e) {
+      // If the file doesn't exist, that's fine. For any other error (e.g. permissions),
+      // we should stop and inform the user.
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: `Error checking for GEMINI.md: ${e instanceof Error ? e.message : String(e)}`,
+        };
+      }
     }
 
-    if (fileExists && !args.includes('--force')) {
+    // Parse arguments properly to avoid matching partial strings
+    const argsArray = args.trim().split(/\s+/);
+    const forceFlag = argsArray.includes('--force');
+    
+    if (fileExists && !forceFlag) {
       return {
         type: 'message',
         messageType: 'info',

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -117,13 +117,22 @@ export interface SubmitPromptActionReturn {
   content: string;
 }
 
+/**
+ * The return type for a command action that needs to submit a query to the AI.
+ */
+export interface SubmitQueryActionReturn {
+  type: 'query';
+  query: string;
+}
+
 export type SlashCommandActionReturn =
   | ToolActionReturn
   | MessageActionReturn
   | QuitActionReturn
   | OpenDialogActionReturn
   | LoadHistoryActionReturn
-  | SubmitPromptActionReturn;
+  | SubmitPromptActionReturn
+  | SubmitQueryActionReturn;
 
 export enum CommandKind {
   BUILT_IN = 'built-in',

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -317,6 +317,11 @@ export const useSlashCommandProcessor = (
                   type: 'submit_prompt',
                   content: result.content,
                 };
+              case 'query':
+                return {
+                  type: 'submit_query',
+                  query: result.query,
+                };
               default: {
                 const unhandled: never = result;
                 throw new Error(`Unhandled slash command result: ${unhandled}`);

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -261,6 +261,15 @@ export const useGeminiStream = (
                 shouldProceed: true,
               };
             }
+            case 'submit_query': {
+              // Add the query as a user message and proceed to send it
+              addItem(
+                { type: MessageType.USER, text: slashCommandResult.query },
+                userMessageTimestamp,
+              );
+              localQueryToSendToGemini = slashCommandResult.query;
+              return { queryToSend: localQueryToSendToGemini, shouldProceed: true };
+            }
             case 'handled': {
               return { queryToSend: null, shouldProceed: false };
             }

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -238,4 +238,8 @@ export type SlashCommandProcessorResult =
   | {
       type: 'handled'; // Indicates the command was processed and no further action is needed.
     }
-  | SubmitPromptResult;
+  | SubmitPromptResult
+  | {
+      type: 'submit_query'; // Submit a query to the AI
+      query: string;
+    };


### PR DESCRIPTION
## TLDR

This PR adds a new `/init` slash command that automatically explores the codebase and generates a GEMINI.md file with project guidance for AI assistants. The command extends the existing command system to support automatic query submission to the LLM.

**🎥 Demo Video**: [Watch the /init command in action](https://www.loom.com/share/f4859c920fdd4268b360f0fe73404d8c?sid=2f5ce1eb-1f1b-4703-b83b-70de87c17aca)

## Dive Deeper

### What's New
- **New `/init` command**: Generates project documentation by exploring the codebase
- **Extended command system**: Added support for commands that automatically submit queries to the AI
- **Systematic exploration**: Provides explicit instructions for using available tools to analyze the project

### Implementation Details
1. Added `SubmitQueryActionReturn` type to allow commands to queue prompts
2. Extended `SlashCommandProcessorResult` with `submit_query` type
3. Updated `useGeminiStream` hook to handle query submissions
4. Created `initCommand` that checks for existing GEMINI.md and sends exploration prompt

### Key Features
- Checks if GEMINI.md already exists (use `--force` to overwrite)
- Lists all available tools with their exact names
- Provides step-by-step exploration instructions
- Automatically triggers AI to create comprehensive documentation

## Reviewer Test Plan

1. Build the project: `npm run build`
2. Start the CLI: `npm start`
3. Run the `/init` command
4. Observe the AI exploring the codebase using various tools
5. Verify GEMINI.md is created with comprehensive project documentation
6. Test overwrite protection by running `/init` again
7. Test force overwrite with `/init --force`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A - This is a new feature addition